### PR TITLE
error prompt fixed when (Neo-)vim loading

### DIFF
--- a/plugin/vimExplorer.vim
+++ b/plugin/vimExplorer.vim
@@ -2856,7 +2856,7 @@ function! VE_ToggleHidden()
 endfunction
 
 command! -nargs=? -complete=file VE    call VENew('<args>')
-command! -nargs=0 -complete=file VEC   call VEDestroy()
+command! -nargs=? -complete=file VEC   call VEDestroy()
 
 
 " vim: set et fdm=marker sts=4 sw=4 tw=78:


### PR DESCRIPTION
[similar issue discussed in Vim](https://github.com/vim/vim/issues/8541#:~:text=With%20the%20command%20%28note%20the%20lack%20of%20-nargs%29%3A,expected%2C%20but%20if%20you%20type%20anything%2C%20for%20example%3A)
an error shows if nargs=0 & complete coexist in recent versions of vim